### PR TITLE
Handle a couple network errors and retry the downloads

### DIFF
--- a/source_pool_fetcher.py
+++ b/source_pool_fetcher.py
@@ -8,6 +8,7 @@ Provides methods for generating pools of source files
 """
 
 from utils.repos import RepoHelper
+from utils.misc import session_get_with_retries
 from pathlib import Path
 from io import BytesIO
 import requests
@@ -111,7 +112,7 @@ class OpenSuseSourceFetcher(BaseSourceFetcher):
         :return: `rpmfile.RPMFile` object
         """
         self.logger.debug(f"Downloading rpm {rpm_url}")
-        package = self.session.get(rpm_url).content
+        package = session_get_with_retries(self.session, rpm_url).content
         return rpmfile.open(fileobj=BytesIO(package))
 
     def fetch_sources(self):

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,6 +1,8 @@
 from urllib3.exceptions import ProtocolError
 from requests.exceptions import ConnectionError, RequestException
 
+import logging
+
 def session_get_with_retries(session, url, tries=4):
     """
     Sometimes downloads fail with connection drops or other temporary errors.
@@ -14,8 +16,9 @@ def session_get_with_retries(session, url, tries=4):
     while tries > 0:
         try:
             return session.get(url)
-        except (ProtocolError , ConnectionError):
+        except (ProtocolError , ConnectionError) as e:
             if tries > 0:
+                logging.warning(f"Request error, trying again: {str(e)}")
                 tries = tries - 1
                 pass
             else:

--- a/utils/misc.py
+++ b/utils/misc.py
@@ -1,0 +1,22 @@
+from urllib3.exceptions import ProtocolError
+from requests.exceptions import ConnectionError, RequestException
+
+def session_get_with_retries(session, url, tries=4):
+    """
+    Sometimes downloads fail with connection drops or other temporary errors.
+    This function catches the known exceptions and retries.
+
+    :param session: A requests.sessions.Session instance to be used
+    :param url: the URL to be retrieved
+    :param tries: number of attempts to make
+    :return: The response from session.get()
+    """
+    while tries > 0:
+        try:
+            return session.get(url)
+        except (ProtocolError , ConnectionError):
+            if tries > 0:
+                tries = tries - 1
+                pass
+            else:
+                raise

--- a/utils/repos.py
+++ b/utils/repos.py
@@ -3,6 +3,7 @@ import gzip
 import logging
 from lxml import objectify
 from urllib.parse import urljoin
+from .misc import session_get_with_retries
 
 class RepoHelper:
     def __init__(self, session=None):
@@ -16,7 +17,7 @@ class RepoHelper:
         :return:
         """
         self.logger.debug(f"Downloading and unpacking {url}")
-        response = self.session.get(url)
+        response = session_get_with_retries(self.session, url)
         try:
             data = gzip.decompress(response.content)
         except gzip.BadGzipFile:


### PR DESCRIPTION
Usually those errors are temporary, so aborting on them is too harsh. The helper function tries again a few times before raising the error.